### PR TITLE
Fix cmd/args issue

### DIFF
--- a/src/it/scala/com/adform/sprint/HighAvailabilityTest.scala
+++ b/src/it/scala/com/adform/sprint/HighAvailabilityTest.scala
@@ -12,7 +12,7 @@ class HighAvailabilityTest extends FlatSpec with Matchers with Eventually with I
 
   implicit override val patienceConfig = PatienceConfig(timeout = Span(60, Seconds), interval = Span(2, Seconds))
 
-  "sprint" should "should only have one leader" in withSprintInstances { (sprint1, sprint2) =>
+  "sprint" should "only have one leader" in withSprintInstances { (sprint1, sprint2) =>
     eventually {
       assert((sprint1.isLeader && !sprint2.isLeader) || (!sprint1.isLeader && sprint2.isLeader))
     }

--- a/src/main/raml/schemas/ContainerRunDefinition.json
+++ b/src/main/raml/schemas/ContainerRunDefinition.json
@@ -5,6 +5,20 @@
   "required": [
     "container"
   ],
+  "not": {
+    "allOf": [
+      {
+        "required": [
+          "cmd"
+        ]
+      },
+      {
+        "required": [
+          "args"
+        ]
+      }
+    ]
+  },
   "properties": {
     "args": {
       "type": "array",
@@ -14,7 +28,8 @@
       }
     },
     "cmd": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "container": {
       "$schema": "http://json-schema.org/schema#",

--- a/src/main/scala/com/adform/sprint/mesos/SprintFramework.scala
+++ b/src/main/scala/com/adform/sprint/mesos/SprintFramework.scala
@@ -222,13 +222,18 @@ class SprintFramework(containerRunManager: ContainerRunManager)(implicit context
     val commandInfo = CommandInfo.newBuilder()
       .setEnvironment(environmentInfo)
 
-    if (containerRun.definition.args.isDefined)
+    if (containerRun.definition.cmd.isDefined) {
+      commandInfo
+        .setShell(true)
+        .setValue(containerRun.definition.cmd.get)
+    } else if (containerRun.definition.args.isDefined) {
       commandInfo
         .setShell(false)
         .addAllArguments(containerRun.definition.args.getOrElse(List.empty[String]).asJava)
-
-    if (containerRun.definition.cmd.isDefined)
-      commandInfo.setValue(containerRun.definition.cmd.get)
+    } else {
+      commandInfo
+        .setShell(false)
+    }
 
     val taskName = containerRun.definition.labels.flatMap(l => l.get("name")).getOrElse(containerRun.id.toString)
     val taskInfo = TaskInfo.newBuilder()


### PR DESCRIPTION
@vixns: tests were failing for PR #6, should not have merged so fast.

After looking more carefully, I think that making `cmd` and `args` exclusive makes sense if we want to have the same semantics as Marathon, where they are exclusive and mean the following:
 - `cmd` is set: `shell=true, value=cmd`, `args` are ignored
 - `args` are set: `shell=false, argv=args`, `value` is not set

They are indeed not exclusive in the mesos `proto` definition, but there you control 3 settings (`shell`, `value`, `argv`), whereas we have only two and IMHO keeping compatibility with Marathon would be the best choice.